### PR TITLE
Allow to stop pre-parameters generator with a context

### DIFF
--- a/common/safe_prime_test.go
+++ b/common/safe_prime_test.go
@@ -7,6 +7,7 @@
 package common
 
 import (
+	"context"
 	"math/big"
 	"runtime"
 	"testing"
@@ -42,7 +43,9 @@ func Test_Validate_Bad(t *testing.T) {
 }
 
 func TestGetRandomGermainPrimeConcurrent(t *testing.T) {
-	sgps, err := GetRandomSafePrimesConcurrent(1024, 2, 20*time.Minute, runtime.NumCPU())
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
+	defer cancel()
+	sgps, err := GetRandomSafePrimesConcurrent(ctx, 1024, 2, runtime.NumCPU())
 	assert.NoError(t, err)
 	assert.Equal(t, 2, len(sgps))
 	for _, sgp := range sgps {

--- a/crypto/mta/range_proof_test.go
+++ b/crypto/mta/range_proof_test.go
@@ -7,6 +7,7 @@
 package mta
 
 import (
+	"context"
 	"math/big"
 	"testing"
 	"time"
@@ -27,7 +28,10 @@ const (
 func TestProveRangeAlice(t *testing.T) {
 	q := tss.EC().Params().N
 
-	sk, pk, err := paillier.GenerateKeyPair(testPaillierKeyLength, 10*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	sk, pk, err := paillier.GenerateKeyPair(ctx, testPaillierKeyLength)
 	assert.NoError(t, err)
 
 	m := common.GetRandomPositiveInt(q)

--- a/crypto/mta/share_protocol_test.go
+++ b/crypto/mta/share_protocol_test.go
@@ -7,6 +7,7 @@
 package mta
 
 import (
+	"context"
 	"math/big"
 	"testing"
 	"time"
@@ -28,7 +29,10 @@ const (
 func TestShareProtocol(t *testing.T) {
 	q := tss.EC().Params().N
 
-	sk, pk, err := paillier.GenerateKeyPair(testPaillierKeyLength, 10*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	sk, pk, err := paillier.GenerateKeyPair(ctx, testPaillierKeyLength)
 	assert.NoError(t, err)
 
 	a := common.GetRandomPositiveInt(q)
@@ -58,7 +62,10 @@ func TestShareProtocol(t *testing.T) {
 func TestShareProtocolWC(t *testing.T) {
 	q := tss.EC().Params().N
 
-	sk, pk, err := paillier.GenerateKeyPair(testPaillierKeyLength, 10*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	sk, pk, err := paillier.GenerateKeyPair(ctx, testPaillierKeyLength)
 	assert.NoError(t, err)
 
 	a := common.GetRandomPositiveInt(q)

--- a/crypto/paillier/paillier.go
+++ b/crypto/paillier/paillier.go
@@ -16,13 +16,13 @@
 package paillier
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	gmath "math"
 	"math/big"
 	"runtime"
 	"strconv"
-	"time"
 
 	"github.com/otiai10/primes"
 
@@ -65,7 +65,7 @@ func init() {
 }
 
 // len is the length of the modulus (each prime = len / 2)
-func GenerateKeyPair(modulusBitLen int, timeout time.Duration, optionalConcurrency ...int) (privateKey *PrivateKey, publicKey *PublicKey, err error) {
+func GenerateKeyPair(ctx context.Context, modulusBitLen int, optionalConcurrency ...int) (privateKey *PrivateKey, publicKey *PublicKey, err error) {
 	var concurrency int
 	if 0 < len(optionalConcurrency) {
 		if 1 < len(optionalConcurrency) {
@@ -81,7 +81,7 @@ func GenerateKeyPair(modulusBitLen int, timeout time.Duration, optionalConcurren
 	{
 		tmp := new(big.Int)
 		for {
-			sgps, err := common.GetRandomSafePrimesConcurrent(modulusBitLen/2, 2, timeout, concurrency)
+			sgps, err := common.GetRandomSafePrimesConcurrent(ctx, modulusBitLen/2, 2, concurrency)
 			if err != nil {
 				return nil, nil, err
 			}

--- a/crypto/paillier/paillier_test.go
+++ b/crypto/paillier/paillier_test.go
@@ -7,6 +7,7 @@
 package paillier_test
 
 import (
+	"context"
 	"math/big"
 	"testing"
 	"time"
@@ -33,8 +34,12 @@ func setUp(t *testing.T) {
 	if privateKey != nil && publicKey != nil {
 		return
 	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
 	var err error
-	privateKey, publicKey, err = GenerateKeyPair(testPaillierKeyLength, 10*time.Minute)
+	privateKey, publicKey, err = GenerateKeyPair(ctx, testPaillierKeyLength)
 	assert.NoError(t, err)
 }
 

--- a/ecdsa/keygen/prepare_test.go
+++ b/ecdsa/keygen/prepare_test.go
@@ -20,7 +20,7 @@ func TestGeneratePreParamsTimeout(t *testing.T) {
 
 	assert.Nil(t, preParams)
 	assert.NotNil(t, err)
-	assert.WithinDuration(t, start, time.Now(), 10*time.Millisecond)
+	assert.WithinDuration(t, start, time.Now(), 1*time.Second)
 }
 
 func TestGeneratePreParamsWithContextTimeout(t *testing.T) {
@@ -32,7 +32,7 @@ func TestGeneratePreParamsWithContextTimeout(t *testing.T) {
 
 	assert.Nil(t, preParams)
 	assert.NotNil(t, err)
-	assert.WithinDuration(t, start, time.Now(), 10*time.Millisecond)
+	assert.WithinDuration(t, start, time.Now(), 1*time.Second)
 }
 
 func TestGenerateWithContext(t *testing.T) {

--- a/ecdsa/keygen/prepare_test.go
+++ b/ecdsa/keygen/prepare_test.go
@@ -1,0 +1,53 @@
+// Copyright © 2019 Binance
+//
+// This file is part of Binance. The full Binance copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+package keygen
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGeneratePreParamsTimeout(t *testing.T) {
+	start := time.Now()
+	preParams, err := GeneratePreParams(5*time.Millisecond, 1)
+
+	assert.Nil(t, preParams)
+	assert.NotNil(t, err)
+	assert.WithinDuration(t, start, time.Now(), 10*time.Millisecond)
+}
+
+func TestGeneratePreParamsWithContextTimeout(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	preParams, err := GeneratePreParamsWithContext(ctx, 1)
+
+	assert.Nil(t, preParams)
+	assert.NotNil(t, err)
+	assert.WithinDuration(t, start, time.Now(), 10*time.Millisecond)
+}
+
+func TestGenerateWithContext(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
+	defer cancel()
+
+	preParams, err := GeneratePreParamsWithContext(ctx, 1)
+	assert.NotNil(t, preParams)
+	assert.Nil(t, err)
+	assert.NotNil(t, preParams.PaillierSK)
+	assert.NotNil(t, preParams.NTildei)
+	assert.NotNil(t, preParams.H1i)
+	assert.NotNil(t, preParams.H2i)
+	assert.NotNil(t, preParams.Alpha)
+	assert.NotNil(t, preParams.Beta)
+	assert.NotNil(t, preParams.P)
+	assert.NotNil(t, preParams.Q)
+}


### PR DESCRIPTION
Refs [#3161](https://github.com/keep-network/keep-core/issues/3161)

I am marking this PR as a draft hoping for an internal review process before I open a PR to `bnb-chain/tss-lib`.

Generating DKG pre-parameters is a computationally expensive operation. As `GeneratePreParams` documentation explains, it is recommended to do it out of band. Keep ECDSA (TBTC) client has a [pre-parameters](https://github.com/keep-network/keep-core/blob/main/pkg/tecdsa/dkg/params_pool.go) pool from which the DKG process pulls pre-parameters to do not have the entire group wait with kicking off DKG until pre-parameters are generated. This approach was sufficient for TBTC v1 when signing groups were 3-of-3. For TBTC v2, we need much larger signing groups (51-of-100) and for clients having multiple seats in the signing group, generating multiple pre-parameters in a row eliminates other processes run by the client from the access to the CPU.

To fix this problem, we plan to run pre-parameters generator only when no other processes are currently executed by the client. That is, when the client would normally be idle, it will keep generating pre-parameters, and when the client starts a protocol execution (e.g. DKG), pre-parameters generation should be stopped.

`GeneratePreParams` allows specifying a timeout which is really helpful but is not enough in this case. We want to stop the generator immediately when some protocol is about to start.

To achieve it, the code has been refactored to accept a context as a parameter of all long-running generator functions. The context can be canceled or can be constructed in such a way that it times out after a certain time. To achieve backward compatibility, `GeneratePreParams` signature does not change and a new function accepting the context `GeneratePreParamsWithContext` has been introduced.

